### PR TITLE
Add CPR Card Payment Reminder Flutter app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# codex
+# CPR - Card Payment Reminder
+
+This Flutter application lets you keep track of credit card due dates and bill dates. Cards can be added, edited and marked as paid. A daily notification at 12 PM reminds you of pending payments.
+
+## Features
+
+- Add cards with name, bill date and due date
+- Edit existing cards
+- Mark cards as paid (records last paid date)
+- Cards auto-reset to unpaid on their bill date
+- Daily local notification showing pending cards
+- Color coded cards (red unpaid, green paid)
+
+## Getting Started
+
+Ensure you have Flutter installed and run:
+
+```bash
+flutter pub get
+flutter run
+```
+
+To build the APK:
+
+```bash
+flutter build apk
+```

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:provider/provider.dart';
+import 'screens/dashboard_screen.dart';
+import 'providers/card_provider.dart';
+
+final FlutterLocalNotificationsPlugin notificationsPlugin =
+    FlutterLocalNotificationsPlugin();
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await _initNotifications();
+  runApp(const MyApp());
+}
+
+Future<void> _initNotifications() async {
+  const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+  const ios = DarwinInitializationSettings();
+  const settings = InitializationSettings(android: android, iOS: ios);
+  await notificationsPlugin.initialize(settings);
+  _scheduleDailyNotification();
+}
+
+void _scheduleDailyNotification() async {
+  const android = AndroidNotificationDetails('daily_id', 'Daily Reminder');
+  const ios = DarwinNotificationDetails();
+  const details = NotificationDetails(android: android, iOS: ios);
+  await notificationsPlugin.zonedSchedule(
+    0,
+    'CPR Reminder',
+    'You have pending card payments',
+    _nextInstanceOfNoon(),
+    details,
+    androidAllowWhileIdle: true,
+    uiLocalNotificationDateInterpretation:
+        UILocalNotificationDateInterpretation.wallClockTime,
+    matchDateTimeComponents: DateTimeComponents.time,
+  );
+}
+
+DateTime _nextInstanceOfNoon() {
+  final now = DateTime.now();
+  final tomorrow = DateTime(now.year, now.month, now.day, 12);
+  return now.isAfter(tomorrow)
+      ? tomorrow.add(const Duration(days: 1))
+      : tomorrow;
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => CardProvider(),
+      child: MaterialApp(
+        title: 'CPR - Card Payment Reminder',
+        theme: ThemeData(primarySwatch: Colors.blue),
+        home: const DashboardScreen(),
+      ),
+    );
+  }
+}

--- a/lib/models/card_item.dart
+++ b/lib/models/card_item.dart
@@ -1,0 +1,15 @@
+class CardItem {
+  String name;
+  int billDate;
+  int dueDate;
+  DateTime? lastPaidOn;
+  bool isPaid;
+
+  CardItem({
+    required this.name,
+    required this.billDate,
+    required this.dueDate,
+    this.lastPaidOn,
+    this.isPaid = false,
+  });
+}

--- a/lib/providers/card_provider.dart
+++ b/lib/providers/card_provider.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import '../models/card_item.dart';
+
+class CardProvider extends ChangeNotifier {
+  final List<CardItem> _cards = [];
+
+  List<CardItem> get cards {
+    _autoReset();
+    _cards.sort((a, b) => a.isPaid == b.isPaid ? 0 : (a.isPaid ? 1 : -1));
+    return List.unmodifiable(_cards);
+  }
+
+  void addCard(CardItem card) {
+    _cards.add(card);
+    notifyListeners();
+  }
+
+  void updateCard(int index, CardItem card) {
+    _cards[index] = card;
+    notifyListeners();
+  }
+
+  void markPaid(int index) {
+    _cards[index].isPaid = true;
+    _cards[index].lastPaidOn = DateTime.now();
+    notifyListeners();
+  }
+
+  void _autoReset() {
+    final now = DateTime.now();
+    for (var card in _cards) {
+      if (now.day == card.billDate) {
+        card.isPaid = false;
+      }
+    }
+  }
+}

--- a/lib/screens/add_card_screen.dart
+++ b/lib/screens/add_card_screen.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/card_item.dart';
+import '../providers/card_provider.dart';
+
+class AddCardScreen extends StatefulWidget {
+  final int? index;
+  final CardItem? card;
+
+  const AddCardScreen({Key? key, this.index, this.card}) : super(key: key);
+
+  @override
+  State<AddCardScreen> createState() => _AddCardScreenState();
+}
+
+class _AddCardScreenState extends State<AddCardScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _billController = TextEditingController();
+  final _dueController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.card != null) {
+      _nameController.text = widget.card!.name;
+      _billController.text = widget.card!.billDate.toString();
+      _dueController.text = widget.card!.dueDate.toString();
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _billController.dispose();
+    _dueController.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    if (_formKey.currentState!.validate()) {
+      final card = CardItem(
+        name: _nameController.text,
+        billDate: int.parse(_billController.text),
+        dueDate: int.parse(_dueController.text),
+        lastPaidOn: widget.card?.lastPaidOn,
+        isPaid: widget.card?.isPaid ?? false,
+      );
+      final provider = context.read<CardProvider>();
+      if (widget.index != null) {
+        provider.updateCard(widget.index!, card);
+      } else {
+        provider.addCard(card);
+      }
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.card == null ? 'Add Card' : 'Edit Card')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Card Name'),
+                validator: (value) => value == null || value.isEmpty ? 'Enter name' : null,
+              ),
+              TextFormField(
+                controller: _billController,
+                decoration: const InputDecoration(labelText: 'Bill Date'),
+                keyboardType: TextInputType.number,
+                validator: (value) => value == null || value.isEmpty ? 'Enter bill date' : null,
+              ),
+              TextFormField(
+                controller: _dueController,
+                decoration: const InputDecoration(labelText: 'Due Date'),
+                keyboardType: TextInputType.number,
+                validator: (value) => value == null || value.isEmpty ? 'Enter due date' : null,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _save,
+                child: Text(widget.card == null ? 'Add Card' : 'Save Changes'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/card_item.dart';
+import '../providers/card_provider.dart';
+import 'add_card_screen.dart';
+
+class DashboardScreen extends StatelessWidget {
+  const DashboardScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<CardProvider>();
+    final cards = provider.cards;
+    return Scaffold(
+      appBar: AppBar(title: const Text('CPR - Card Payment Reminder')),
+      body: ListView.builder(
+        itemCount: cards.length,
+        itemBuilder: (context, index) {
+          final card = cards[index];
+          return Card(
+            color: card.isPaid ? Colors.green[100] : Colors.red[100],
+            child: ListTile(
+              title: Text(card.name),
+              subtitle: Text('Bill: ${card.billDate}  Due: ${card.dueDate}\nLast Paid: '
+                  '${card.lastPaidOn != null ? card.lastPaidOn!.toLocal().toString().split(' ').first : 'Never'}'),
+              isThreeLine: true,
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.check),
+                    onPressed: card.isPaid ? null : () => provider.markPaid(index),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.edit),
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => AddCardScreen(index: index, card: card),
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const AddCardScreen()),
+        ),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,15 @@
+name: cpr_card_payment_reminder
+version: 1.0.0
+publish_to: 'none'
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_local_notifications: ^12.0.4
+  cupertino_icons: ^1.0.2
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- implement simple Flutter app called CPR Card Payment Reminder
- manage card data with provider and auto reset on bill date
- list unpaid cards first with editing and mark-paid options
- daily local notification at noon about pending cards
- documentation for running the app

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683fc15574e883328bbdd93c3f357930